### PR TITLE
Dev. v2022.2 - Readmes updated to reflect new features

### DIFF
--- a/FlashPro_Express_Projects/README.md
+++ b/FlashPro_Express_Projects/README.md
@@ -33,8 +33,9 @@ The Libero designs include the following features:
 * The operating frequency of the design is 50MHz
 * Target memory is SRAM/TCM (32kB)
 * User peripherals: 2 Timers, UART, 2 GPIO Inputs and 4 GPIO Outputs (GPIOs use fixed configs for simplicity and better resource utilization)
-The peripherals in this design are located at the following addresses.
 
+
+The peripherals in this design are located at the following addresses.
 #### MIV_RV32 based configurations
 | Peripheral (MIV_ESS)             | Address Start | Address End    |
 | ------------------------------:  |:-------------:|:--------------:|

--- a/FlashPro_Express_Projects/README.md
+++ b/FlashPro_Express_Projects/README.md
@@ -1,6 +1,6 @@
 ## Future Avalanche Board FPGA Programming Files
 
-This folder contains FlashPro Express v2022.1 projects for the Future Avalanche Board Mi-V sample designs.
+This folder contains FlashPro Express v2022.2 projects for the Future Avalanche Board Mi-V sample designs.
 
 ## FlashPro Express
 The programming files contained under this folder were exported from the designs in the Libero_Projects folder in this repository. Select the desired programming file (.job) and program your device using FlashPro Express.
@@ -29,17 +29,40 @@ The following applies only to non MIV_ESS Design Guide: Design Guide Configurati
 The Libero designs include the following features:
 * A soft RISC-V processor.
 * A RISC-V debug block allowing on-target debug using SoftConsole
+* An Extended subsystem with peripheral cores
 * The operating frequency of the design is 50MHz
 * Target memory is SRAM/TCM (32kB)
 * User peripherals: 2 Timers, UART, 2 GPIO Inputs and 4 GPIO Outputs (GPIOs use fixed configs for simplicity and better resource utilization)
 
+The peripherals for MIV_RV32 configuration designs are located at the following addresses.
+
+| Peripheral                       | Address Start | Address End    |
+| ------------------------------:  |:-------------:|:--------------:|
+| PLIC                             | 0x7000_0000   | 0x70FF_FFFF    |
+| CoreUARTapb                      | 0x7100_0000   | 0x71FF_FFFF    |
+| Timer                            | 0x7200_0000   | 0x72FF_FFFF    |
+| CoreTimer_0 / MIV_ESS_APBSLOT3   | 0x7300_0000   | 0x73FF_FFFF    |
+| CoreTimer_1 / MIV_ESS_APBSLOT4   | 0x7400_0000   | 0x74FF_FFFF    |
+| CoreGPIO                         | 0x7500_0000   | 0x75FF_FFFF    |
+| SPI                              | 0x7600_0000   | 0x76FF_FFFF    |
+| uDMA                             | 0x7800_0000   | 0x78FF_FFFF    |
+| WDOG                             | 0x7900_0000   | 0x79FF_FFFF    |
+| I2C                              | 0x7A00_0000   | 0x7AFF_FFFF    |
+| MIV_ESS_APBSLOTB_BASE            | 0x7B00_0000   | 0x7BFF_FFFF    |
+| MIV_ESS_APBSLOTC_BASE            | 0x7C00_0000   | 0x7CFF_FFFF    |
+| MIV_ESS_APBSLOTD_BASE            | 0x7D00_0000   | 0x7DFF_FFFF    |
+| MIV_ESS_APBSLOTE_BASE            | 0x7E00_0000   | 0x7EFF_FFFF    |
+| MIV_ESS_APBSLOTF_BASE            | 0x7F00_0000   | 0x7FFF_FFFF    |
+| SRAM/TCM                         | 0x8000_0000   | 0x8000_7FFF    |
+
+
 The peripherals in this design are located at the following addresses.
 
-| Peripheral    | Address   |
+| Peripheral    | Address       |
 | ------------- |:-------------:|
 | CoreUARTapb   | 0x7000_1000   |
 | CoreGPIO_IN   | 0x7000_2000   |
 | CoreTimer_0   | 0x7000_3000   |
 | CoreTimer_1   | 0x7000_4000   |
 | CoreGPIO_OUT  | 0x7000_5000   |
-| SRAM| 0x8000_0000|
+| SRAM          | 0x8000_0000   |

--- a/FlashPro_Express_Projects/README.md
+++ b/FlashPro_Express_Projects/README.md
@@ -33,10 +33,10 @@ The Libero designs include the following features:
 * The operating frequency of the design is 50MHz
 * Target memory is SRAM/TCM (32kB)
 * User peripherals: 2 Timers, UART, 2 GPIO Inputs and 4 GPIO Outputs (GPIOs use fixed configs for simplicity and better resource utilization)
+The peripherals in this design are located at the following addresses.
 
-The peripherals for MIV_RV32 configuration designs are located at the following addresses.
-
-| Peripheral                       | Address Start | Address End    |
+#### MIV_RV32 based configurations
+| Peripheral (MIV_ESS)             | Address Start | Address End    |
 | ------------------------------:  |:-------------:|:--------------:|
 | PLIC                             | 0x7000_0000   | 0x70FF_FFFF    |
 | CoreUARTapb                      | 0x7100_0000   | 0x71FF_FFFF    |
@@ -56,13 +56,12 @@ The peripherals for MIV_RV32 configuration designs are located at the following 
 | SRAM/TCM                         | 0x8000_0000   | 0x8000_7FFF    |
 
 
-The peripherals in this design are located at the following addresses.
-
-| Peripheral    | Address       |
-| ------------- |:-------------:|
-| CoreUARTapb   | 0x7000_1000   |
-| CoreGPIO_IN   | 0x7000_2000   |
-| CoreTimer_0   | 0x7000_3000   |
-| CoreTimer_1   | 0x7000_4000   |
-| CoreGPIO_OUT  | 0x7000_5000   |
-| SRAM          | 0x8000_0000   |
+#### Legacy core based configurations:
+| Peripheral (Standalone)| Address       |
+| ----------------------:|:-------------:|
+| CoreUARTapb            | 0x7000_1000   |
+| CoreGPIO_IN            | 0x7000_2000   |
+| CoreTimer_0            | 0x7000_3000   |
+| CoreTimer_1            | 0x7000_4000   |
+| CoreGPIO_OUT           | 0x7000_5000   |
+| SRAM                   | 0x8000_0000   |

--- a/FlashPro_Express_Projects/README.md
+++ b/FlashPro_Express_Projects/README.md
@@ -27,12 +27,11 @@ The programming files contained under this folder were exported from the designs
 The following applies only to non MIV_ESS Design Guide: Design Guide Configurations (DGC2)
 
 The Libero designs include the following features:
-* A soft RISC-V processor.
+* A soft RISC-V processor operating at 50 MHz
 * A RISC-V debug block allowing on-target debug using SoftConsole
-* An Extended subsystem with peripheral cores
-* The operating frequency of the design is 50MHz
-* Target memory is SRAM/TCM (32kB)
-* User peripherals: 2 Timers, UART, 2 GPIO Inputs and 4 GPIO Outputs (GPIOs use fixed configs for simplicity and better resource utilization)
+* An Extended Subsystem with integrated peripherals
+* Target SRAM/TCM memory (32kB)
+* User peripherals: MIV_ESS, 2 Timers, UART, 2 GPIO Inputs and 4 GPIO Outputs (GPIOs use fixed configs for simplicity and better resource utilization)
 
 
 The peripherals in this design are located at the following addresses.

--- a/FlashPro_Express_Projects/README.md
+++ b/FlashPro_Express_Projects/README.md
@@ -40,11 +40,11 @@ The peripherals in this design are located at the following addresses.
 | Peripheral (MIV_ESS)             | Address Start | Address End    |
 | ------------------------------:  |:-------------:|:--------------:|
 | PLIC                             | 0x7000_0000   | 0x70FF_FFFF    |
-| CoreUARTapb                      | 0x7100_0000   | 0x71FF_FFFF    |
+| UART                             | 0x7100_0000   | 0x71FF_FFFF    |
 | Timer                            | 0x7200_0000   | 0x72FF_FFFF    |
 | CoreTimer_0 / MIV_ESS_APBSLOT3   | 0x7300_0000   | 0x73FF_FFFF    |
 | CoreTimer_1 / MIV_ESS_APBSLOT4   | 0x7400_0000   | 0x74FF_FFFF    |
-| CoreGPIO                         | 0x7500_0000   | 0x75FF_FFFF    |
+| GPIO                             | 0x7500_0000   | 0x75FF_FFFF    |
 | SPI                              | 0x7600_0000   | 0x76FF_FFFF    |
 | uDMA                             | 0x7800_0000   | 0x78FF_FFFF    |
 | WDOG                             | 0x7900_0000   | 0x79FF_FFFF    |

--- a/Libero_Projects/README.md
+++ b/Libero_Projects/README.md
@@ -97,11 +97,11 @@ The peripherals in this design are located at the following addresses.
 | Peripheral (MIV_ESS)             | Address Start | Address End    |
 | ------------------------------:  |:-------------:|:--------------:|
 | PLIC                             | 0x7000_0000   | 0x70FF_FFFF    |
-| CoreUARTapb                      | 0x7100_0000   | 0x71FF_FFFF    |
+| UART                             | 0x7100_0000   | 0x71FF_FFFF    |
 | Timer                            | 0x7200_0000   | 0x72FF_FFFF    |
 | CoreTimer_0 / MIV_ESS_APBSLOT3   | 0x7300_0000   | 0x73FF_FFFF    |
 | CoreTimer_1 / MIV_ESS_APBSLOT4   | 0x7400_0000   | 0x74FF_FFFF    |
-| CoreGPIO                         | 0x7500_0000   | 0x75FF_FFFF    |
+| GPIO                             | 0x7500_0000   | 0x75FF_FFFF    |
 | SPI                              | 0x7600_0000   | 0x76FF_FFFF    |
 | uDMA                             | 0x7800_0000   | 0x78FF_FFFF    |
 | WDOG                             | 0x7900_0000   | 0x79FF_FFFF    |

--- a/Libero_Projects/README.md
+++ b/Libero_Projects/README.md
@@ -91,9 +91,10 @@ The Libero designs include the following features:
 * User peripherals: MIV_ESS, 2 Timers, UART, 2 GPIO Inputs and 4 GPIO Outputs (GPIOs use fixed configs for simplicity and better resource utilization)
 
 
-The peripherals for MIV_RV32 configuration designs are located at the following addresses.
+The peripherals in this design are located at the following addresses.
 
-| Peripheral                       | Address Start | Address End    |
+#### MIV_RV32 based configurations
+| Peripheral (MIV_ESS)             | Address Start | Address End    |
 | ------------------------------:  |:-------------:|:--------------:|
 | PLIC                             | 0x7000_0000   | 0x70FF_FFFF    |
 | CoreUARTapb                      | 0x7100_0000   | 0x71FF_FFFF    |
@@ -113,13 +114,12 @@ The peripherals for MIV_RV32 configuration designs are located at the following 
 | SRAM/TCM                         | 0x8000_0000   | 0x8000_7FFF    |
 
 
-The peripherals in this design are located at the following addresses.
-
-| Peripheral    | Address       |
-| ------------- |:-------------:|
-| CoreUARTapb   | 0x7000_1000   |
-| CoreGPIO_IN   | 0x7000_2000   |
-| CoreTimer_0   | 0x7000_3000   |
-| CoreTimer_1   | 0x7000_4000   |
-| CoreGPIO_OUT  | 0x7000_5000   |
-| SRAM          | 0x8000_0000   |
+#### Legacy core based configurations:
+| Peripheral (Standalone)| Address       |
+| ----------------------:|:-------------:|
+| CoreUARTapb            | 0x7000_1000   |
+| CoreGPIO_IN            | 0x7000_2000   |
+| CoreTimer_0            | 0x7000_3000   |
+| CoreTimer_1            | 0x7000_4000   |
+| CoreGPIO_OUT           | 0x7000_5000   |
+| SRAM                   | 0x8000_0000   |

--- a/Libero_Projects/README.md
+++ b/Libero_Projects/README.md
@@ -9,9 +9,9 @@ This folder contains Tcl scripts that build Libero SoC v2022.2 design projects f
 
 | Config  | Description|
 | :------:|:----------------------------------------|
-| CFG1    | This design uses the MIV_RV32 core configured as follows: <ul><li>RISC-V Extensions: IMC</li><li>Multiplier: MACC (Pipelined)</li><li>Interfaces: AHB Master (mirrored), APB3 Master</li><li>Internal IRQs: 1</li><li>TCM: Enabled</li><li>System Timer: Internal MTIME enabled, Internal MTIME IRQ enabled</li><li>Debug: enabled</li></ul>|
-| CFG2    | This design uses the MIV_RV32 core configured as follows: <ul><li>RISC-V Extensions: IM</li><li>Multiplier: Fabric</li><li>Interfaces: AXI4 Master (mirrored), APB3 Master</li><li>Internal IRQs: 1</li><li>TCM: Disabled</li><li>System Timer: Internal MTIME enabled, Internal MTIME IRQ enabled</li><li>Debug: enabled</li></ul>|
-| CFG3    | This design uses the MIV_RV32 core configured as follows: <ul><li>RISC-V Extensions: I</li><li>Multiplier: none</li><li>Interfaces: APB3 Master</li><li>Internal IRQs: 1</li><li>TCM: Enabled</li><li>System Timer: Internal MTIME enabled, Internal MTIME IRQ enabled</li><li>Debug: enabled</li></ul>|
+| CFG1    | This design uses the MIV_RV32 core configured as follows: <ul><li>RISC-V Extensions: IMC</li><li>Multiplier: MACC (Pipelined)</li><li>Interfaces: AHB Master (mirrored), APB3 Master</li><li>Internal IRQs: 1</li><li>TCM: Enabled</li><li>System Timer: Internal MTIME enabled, Internal MTIME IRQ enabled</li><li>Debug: Enabled</li></ul>|
+| CFG2    | This design uses the MIV_RV32 core configured as follows: <ul><li>RISC-V Extensions: IM</li><li>Multiplier: Fabric</li><li>Interfaces: AXI4 Master (mirrored), APB3 Master</li><li>Internal IRQs: 1</li><li>TCM: Disabled</li><li>System Timer: Internal MTIME enabled, Internal MTIME IRQ enabled</li><li>Debug: Enabled</li></ul>|
+| CFG3    | This design uses the MIV_RV32 core configured as follows: <ul><li>RISC-V Extensions: I</li><li>Multiplier: none</li><li>Interfaces: APB3 Master</li><li>Internal IRQs: 1</li><li>TCM: Enabled</li><li>System Timer: Internal MTIME enabled, Internal MTIME IRQ enabled</li><li>Debug: Enabled</li></ul>|
     
 
 #### PF_Avalanche_MIV_RV32IMA_BaseDesign
@@ -83,11 +83,10 @@ In the examples above the arguments "CFG1" and "CFG1 SYNTHESIZE PS" were entered
 
 ## Design Features
 The Libero designs include the following features:
-* A soft RISC-V processor.
+* A soft RISC-V processor operating at 50 MHz
 * A RISC-V debug block allowing on-target debug using SoftConsole
-* An Extended subsystem with peripheral cores
-* The operating frequency of the design is 50MHz
-* Target memory is SRAM/TCM (32kB)
+* An Extended Subsystem with integrated peripherals
+* Target SRAM/TCM memory (32kB)
 * User peripherals: MIV_ESS, 2 Timers, UART, 2 GPIO Inputs and 4 GPIO Outputs (GPIOs use fixed configs for simplicity and better resource utilization)
 
 

--- a/Libero_Projects/README.md
+++ b/Libero_Projects/README.md
@@ -114,17 +114,14 @@ The peripherals for MIV_RV32 configuration designs are located at the following 
 | MIV_ESS_APBSLOTF_BASE            | 0x7F00_0000   | 0x7FFF_FFFF    |
 | SRAM/TCM                         | 0x8000_0000   | 0x8000_7FFF    |
 
-
-Peripherals addresses for legacy cores are as 
-
-| Peripheral    | Address   |
+| Peripheral    | Address       |
 | ------------- |:-------------:|
 | CoreUARTapb   | 0x7000_1000   |
 | CoreGPIO_IN   | 0x7000_2000   |
 | CoreTimer_0   | 0x7000_3000   |
 | CoreTimer_1   | 0x7000_4000   |
 | CoreGPIO_OUT  | 0x7000_5000   |
-| SRAM          | 0x8000_0000   |
+| SRAM     | 0x8000_0000|
 
 | Script                                | Configuration | Memory     | Address                   |
 | PF_Avalanche_MIV_RV32_BaseDesign      | CFG1          | SRAM/TCM   | 0x8000_0000 / 0x4000_0000 |

--- a/Libero_Projects/README.md
+++ b/Libero_Projects/README.md
@@ -9,9 +9,9 @@ This folder contains Tcl scripts that build Libero SoC v2022.2 design projects f
 
 | Config  | Description|
 | :------:|:----------------------------------------|
-| CFG1    | This design uses the MIV_RV32 core configured as follows: <ul><li>RISC-V Extensions: IMC</li><li>Multiplier: MACC (Pipelined)</li><li>Interfaces: AHB Master (mirrored), APB3 Master</li><li>Internal IRQs: 1</li><li>TCM: Enabled</li><li>System Timer: Internal MTIME enabled, Internal MTIME IRQ enabled</li><li>Debug: enabled</li><li>Peripheral Subsystem: MIV_ESS</li></ul>|
+| CFG1    | This design uses the MIV_RV32 core configured as follows: <ul><li>RISC-V Extensions: IMC</li><li>Multiplier: MACC (Pipelined)</li><li>Interfaces: AHB Master (mirrored), APB3 Master</li><li>Internal IRQs: 1</li><li>TCM: Enabled</li><li>System Timer: Internal MTIME enabled, Internal MTIME IRQ enabled</li><li>Debug: enabled</li></ul>|
 | CFG2    | This design uses the MIV_RV32 core configured as follows: <ul><li>RISC-V Extensions: IM</li><li>Multiplier: Fabric</li><li>Interfaces: AXI4 Master (mirrored), APB3 Master</li><li>Internal IRQs: 1</li><li>TCM: Disabled</li><li>System Timer: Internal MTIME enabled, Internal MTIME IRQ enabled</li><li>Debug: enabled</li></ul>|
-| CFG3    | This design uses the MIV_RV32 core configured as follows: <ul><li>RISC-V Extensions: I</li><li>Multiplier: none</li><li>Interfaces: APB3 Master</li><li>Internal IRQs: 1</li><li>TCM: Enabled</li><li>System Timer: Internal MTIME enabled, Internal MTIME IRQ enabled</li><li>Debug: enabled</li><li>Peripheral Subsystem: MIV_ESS</li></ul>|
+| CFG3    | This design uses the MIV_RV32 core configured as follows: <ul><li>RISC-V Extensions: I</li><li>Multiplier: none</li><li>Interfaces: APB3 Master</li><li>Internal IRQs: 1</li><li>TCM: Enabled</li><li>System Timer: Internal MTIME enabled, Internal MTIME IRQ enabled</li><li>Debug: enabled</li></ul>|
     
 
 #### PF_Avalanche_MIV_RV32IMA_BaseDesign
@@ -90,8 +90,6 @@ The Libero designs include the following features:
 * Target memory is SRAM/TCM (32kB)
 * User peripherals: MIV_ESS, 2 Timers, UART, 2 GPIO Inputs and 4 GPIO Outputs (GPIOs use fixed configs for simplicity and better resource utilization)
 
-> MI-V Extended Subsystem Design Guide Configurations:
-> * For **DGC2: I2C Write & Boot** design features, refer to [DGC2 README](import/components/IMC_DGC2/README.md)
 
 The peripherals for MIV_RV32 configuration designs are located at the following addresses.
 
@@ -114,6 +112,9 @@ The peripherals for MIV_RV32 configuration designs are located at the following 
 | MIV_ESS_APBSLOTF_BASE            | 0x7F00_0000   | 0x7FFF_FFFF    |
 | SRAM/TCM                         | 0x8000_0000   | 0x8000_7FFF    |
 
+
+The peripherals in this design are located at the following addresses.
+
 | Peripheral    | Address       |
 | ------------- |:-------------:|
 | CoreUARTapb   | 0x7000_1000   |
@@ -121,11 +122,4 @@ The peripherals for MIV_RV32 configuration designs are located at the following 
 | CoreTimer_0   | 0x7000_3000   |
 | CoreTimer_1   | 0x7000_4000   |
 | CoreGPIO_OUT  | 0x7000_5000   |
-| SRAM     | 0x8000_0000|
-
-| Script                                | Configuration | Memory     | Address                   |
-| PF_Avalanche_MIV_RV32_BaseDesign      | CFG1          | SRAM/TCM   | 0x8000_0000 / 0x4000_0000 |
-|                                       | CFG2          | SRAM       | 0x8000_0000               |
-|                                       | CFG3          | SRAM       | 0x8000_0000               |
-| PF_Avalanche_MIV_RV32IMA_BaseDesign   | CFG1          |
-
+| SRAM          | 0x8000_0000   |

--- a/Libero_Projects/README.md
+++ b/Libero_Projects/README.md
@@ -9,24 +9,24 @@ This folder contains Tcl scripts that build Libero SoC v2022.2 design projects f
 
 | Config  | Description|
 | :------:|:----------------------------------------|
-| CFG1    | This design uses the MIV_RV32 core configured as follows: <ul><li>RISC-V Extensions: IMC</li><li>Multiplier: MACC (Pipelined)</li><li>Interfaces: AHB Master (mirrored), APB3 Master</li><li>Internal IRQs: 1</li><li>TCM: Enabled</li><li>System Timer: Internal MTIME enabled, Internal MTIME IRQ enabled</li><li>Debug: enabled</li></ul>|
+| CFG1    | This design uses the MIV_RV32 core configured as follows: <ul><li>RISC-V Extensions: IMC</li><li>Multiplier: MACC (Pipelined)</li><li>Interfaces: AHB Master (mirrored), APB3 Master</li><li>Internal IRQs: 1</li><li>TCM: Enabled</li><li>System Timer: Internal MTIME enabled, Internal MTIME IRQ enabled</li><li>Debug: enabled</li><li>Peripheral Subsystem: MIV_ESS</li></ul>|
 | CFG2    | This design uses the MIV_RV32 core configured as follows: <ul><li>RISC-V Extensions: IM</li><li>Multiplier: Fabric</li><li>Interfaces: AXI4 Master (mirrored), APB3 Master</li><li>Internal IRQs: 1</li><li>TCM: Disabled</li><li>System Timer: Internal MTIME enabled, Internal MTIME IRQ enabled</li><li>Debug: enabled</li></ul>|
-| CFG3    | This design uses the MIV_RV32 core configured as follows: <ul><li>RISC-V Extensions: I</li><li>Multiplier: none</li><li>Interfaces: APB3 Master</li><li>Internal IRQs: 1</li><li>TCM: Enabled</li><li>System Timer: Internal MTIME enabled, Internal MTIME IRQ enabled</li><li>Debug: enabled</li></ul>|
+| CFG3    | This design uses the MIV_RV32 core configured as follows: <ul><li>RISC-V Extensions: I</li><li>Multiplier: none</li><li>Interfaces: APB3 Master</li><li>Internal IRQs: 1</li><li>TCM: Enabled</li><li>System Timer: Internal MTIME enabled, Internal MTIME IRQ enabled</li><li>Debug: enabled</li><li>Peripheral Subsystem: MIV_ESS</li></ul>|
     
 
 #### PF_Avalanche_MIV_RV32IMA_BaseDesign
 
 | Config  | Description |
 | :------:|:------------|
-| CFG1    |This design uses the MIV_RV32IMA_L1_AHB core with an **AHB** interface for memory and peripherals|
-| CFG2    |This design uses the MIV_RV32IMA_L1_AXI core with an **AXI3** interface for memory and peripherals|
+| CFG1    | This design uses the MIV_RV32IMA_L1_AHB core with an **AHB** interface for memory and peripherals|
+| CFG2    | This design uses the MIV_RV32IMA_L1_AXI core with an **AXI3** interface for memory and peripherals|
 
 
 #### PF_Avalanche_MIV_RV32IMAF_BaseDesign
 
 | Config  |Description |
 | :------:|:-----------|
-| CFG1    |  This design uses the MIV_RV32IMAF_L1_AHB core with an **AHB** interface for memory and peripherals|
+| CFG1    | This design uses the MIV_RV32IMAF_L1_AHB core with an **AHB** interface for memory and peripherals|
 
 
 ## <a name="quick"></a> Instructions
@@ -85,6 +85,7 @@ In the examples above the arguments "CFG1" and "CFG1 SYNTHESIZE PS" were entered
 The Libero designs include the following features:
 * A soft RISC-V processor.
 * A RISC-V debug block allowing on-target debug using SoftConsole
+* An Extended subsystem with peripheral cores
 * The operating frequency of the design is 50MHz
 * Target memory is SRAM/TCM (32kB)
 * User peripherals: MIV_ESS, 2 Timers, UART, 2 GPIO Inputs and 4 GPIO Outputs (GPIOs use fixed configs for simplicity and better resource utilization)
@@ -111,6 +112,8 @@ The peripherals for MIV_RV32 configuration designs are located at the following 
 | MIV_ESS_APBSLOTD_BASE            | 0x7D00_0000   | 0x7DFF_FFFF    |
 | MIV_ESS_APBSLOTE_BASE            | 0x7E00_0000   | 0x7EFF_FFFF    |
 | MIV_ESS_APBSLOTF_BASE            | 0x7F00_0000   | 0x7FFF_FFFF    |
+| SRAM/TCM                         | 0x8000_0000   | 0x8000_7FFF    |
+
 
 Peripherals addresses for legacy cores are as 
 

--- a/Libero_Projects/README.md
+++ b/Libero_Projects/README.md
@@ -1,5 +1,5 @@
 ## Future Avalanche Board Mi-V Sample FPGA Designs
-This folder contains Tcl scripts that build Libero SoC v2022.1 design projects for the Future Avalanche Board. These scripts are executed in Libero SoC to generate the sample designs. All Configuration (CFG) design cores boot from memory at 0x8000_0000.
+This folder contains Tcl scripts that build Libero SoC v2022.2 design projects for the Future Avalanche Board. These scripts are executed in Libero SoC to generate the sample designs. All Configuration (CFG) design cores boot from memory at 0x8000_0000.
 
 > MI-V Extended Subsystem Design Guide Configurations:
 > * For **Design Guide Configuration - DGC2: I2C Write & Boot** refer to this [DGC2 README](import/components/IMC_DGC2/README.md)
@@ -92,7 +92,27 @@ The Libero designs include the following features:
 > MI-V Extended Subsystem Design Guide Configurations:
 > * For **DGC2: I2C Write & Boot** design features, refer to [DGC2 README](import/components/IMC_DGC2/README.md)
 
-The peripherals in this design are located at the following addresses.
+The peripherals for MIV_RV32 configuration designs are located at the following addresses.
+
+| Peripheral                       | Address Start | Address End    |
+| ------------------------------:  |:-------------:|:--------------:|
+| PLIC                             | 0x7000_0000   | 0x70FF_FFFF    |
+| CoreUARTapb                      | 0x7100_0000   | 0x71FF_FFFF    |
+| Timer                            | 0x7200_0000   | 0x72FF_FFFF    |
+| CoreTimer_0 / MIV_ESS_APBSLOT3   | 0x7300_0000   | 0x73FF_FFFF    |
+| CoreTimer_1 / MIV_ESS_APBSLOT4   | 0x7400_0000   | 0x74FF_FFFF    |
+| CoreGPIO                         | 0x7500_0000   | 0x75FF_FFFF    |
+| SPI                              | 0x7600_0000   | 0x76FF_FFFF    |
+| uDMA                             | 0x7800_0000   | 0x78FF_FFFF    |
+| WDOG                             | 0x7900_0000   | 0x79FF_FFFF    |
+| I2C                              | 0x7A00_0000   | 0x7AFF_FFFF    |
+| MIV_ESS_APBSLOTB_BASE            | 0x7B00_0000   | 0x7BFF_FFFF    |
+| MIV_ESS_APBSLOTC_BASE            | 0x7C00_0000   | 0x7CFF_FFFF    |
+| MIV_ESS_APBSLOTD_BASE            | 0x7D00_0000   | 0x7DFF_FFFF    |
+| MIV_ESS_APBSLOTE_BASE            | 0x7E00_0000   | 0x7EFF_FFFF    |
+| MIV_ESS_APBSLOTF_BASE            | 0x7F00_0000   | 0x7FFF_FFFF    |
+
+Peripherals addresses for legacy cores are as 
 
 | Peripheral    | Address   |
 | ------------- |:-------------:|
@@ -101,4 +121,11 @@ The peripherals in this design are located at the following addresses.
 | CoreTimer_0   | 0x7000_3000   |
 | CoreTimer_1   | 0x7000_4000   |
 | CoreGPIO_OUT  | 0x7000_5000   |
-| SRAM| 0x8000_0000|
+| SRAM          | 0x8000_0000   |
+
+| Script                                | Configuration | Memory     | Address                   |
+| PF_Avalanche_MIV_RV32_BaseDesign      | CFG1          | SRAM/TCM   | 0x8000_0000 / 0x4000_0000 |
+|                                       | CFG2          | SRAM       | 0x8000_0000               |
+|                                       | CFG3          | SRAM       | 0x8000_0000               |
+| PF_Avalanche_MIV_RV32IMA_BaseDesign   | CFG1          |
+

--- a/Libero_Projects/import/components/IMC_DGC2/README.md
+++ b/Libero_Projects/import/components/IMC_DGC2/README.md
@@ -111,7 +111,7 @@ A more detailed description of the boot sequence can be found in this section.
 | Timer                            | 0x7200_0000   | 0x72FF_FFFF    |
 | CoreTimer_0 / MIV_ESS_APBSLOT3   | 0x7300_0000   | 0x73FF_FFFF    |
 | CoreTimer_1 / MIV_ESS_APBSLOT4   | 0x7400_0000   | 0x74FF_FFFF    |
-| CoreGPIO_OUT                     | 0x7500_0000   | 0x75FF_FFFF    |
+| CoreGPIO                         | 0x7500_0000   | 0x75FF_FFFF    |
 | SPI                              | 0x7600_0000   | 0x76FF_FFFF    |
 | uDMA                             | 0x7800_0000   | 0x78FF_FFFF    |
 | WDOG                             | 0x7900_0000   | 0x79FF_FFFF    |

--- a/Libero_Projects/import/components/IMC_DGC2/README.md
+++ b/Libero_Projects/import/components/IMC_DGC2/README.md
@@ -107,11 +107,11 @@ A more detailed description of the boot sequence can be found in this section.
 | Peripheral                       | Address Start | Address End    |
 | ------------------------------:  |:-------------:|:--------------:|
 | PLIC                             | 0x7000_0000   | 0x70FF_FFFF    |
-| CoreUARTapb                      | 0x7100_0000   | 0x71FF_FFFF    |
+| UART                             | 0x7100_0000   | 0x71FF_FFFF    |
 | Timer                            | 0x7200_0000   | 0x72FF_FFFF    |
 | CoreTimer_0 / MIV_ESS_APBSLOT3   | 0x7300_0000   | 0x73FF_FFFF    |
 | CoreTimer_1 / MIV_ESS_APBSLOT4   | 0x7400_0000   | 0x74FF_FFFF    |
-| CoreGPIO                         | 0x7500_0000   | 0x75FF_FFFF    |
+| GPIO                             | 0x7500_0000   | 0x75FF_FFFF    |
 | SPI                              | 0x7600_0000   | 0x76FF_FFFF    |
 | uDMA                             | 0x7800_0000   | 0x78FF_FFFF    |
 | WDOG                             | 0x7900_0000   | 0x79FF_FFFF    |

--- a/Libero_Projects/import/components/IMC_DGC2/README.md
+++ b/Libero_Projects/import/components/IMC_DGC2/README.md
@@ -82,11 +82,10 @@ To run the Bootloader .elf program, follow the steps below or refer to the *MIV_
 
 ### Features
 The Libero designs include the following features:
-* A soft RISC-V processor.
+* A soft RISC-V processor operating at 50 MHz
 * A RISC-V debug block allowing on-target debug using SoftConsole
-* An Extended subsystem with peripheral cores
-* The operating frequency of the design is 50MHz
-* Target memory is SRAM/TCM (32kB)
+* An Extended Subsystem with integrated peripherals
+* Target SRAM/TCM memory (32kB)
 * User peripherals: MIV_ESS (Bootstrap, I2C, GPIO, UART)
 
 ### Boot Sequence Operation

--- a/Libero_Projects/import/components/IMC_DGC2/README.md
+++ b/Libero_Projects/import/components/IMC_DGC2/README.md
@@ -1,6 +1,6 @@
 ## Mi-V Extended Subsystem Design Guide Configuration 2: I2C Write & Boot
-This folder contains Tcl scripts that build Libero SoC v2022.1 MIV_ESS DGC2 design project for the Future Avalanche Board. The script is executed in Libero SoC to generate the sample design. 
-> Design is catered for Libero SoC v2022.1. Using older versions of Libero SoC will result in errors.
+This folder contains Tcl scripts that build Libero SoC v2022.2 MIV_ESS DGC2 design project for the Future Avalanche Board. The script is executed in Libero SoC to generate the sample design. 
+> Design is catered for Libero SoC v2022.2. Using older versions of Libero SoC will result in errors.
 
 #### PF_Avalanche_MIV_RV32_BaseDesign
 
@@ -55,7 +55,7 @@ The complete set of script arguments are documented here.
 ## <a name="Software Provided"></a> Software Provided
 There are two programs included with this configuration:
 * **miv-rv32i-systick-blinky.hex**: A Hex program configured to run from TCM's address (0x4000_0000). The program is initialized in the LSRAM component at 0x8000_0000 and it is accessible over the AHB interface.
-    > The example hex program was created using  miv-rv32i-systick-blinky in release mode (miv32i-Release). For more information about the project go to bare metal example: [miv-rv32i-systick-blinky](https://github.com/Mi-V-Soft-RISC-V/miv-rv32-bare-metal-examples/tree/main/applications/miv-rv32-hal/miv-rv32i-systick-blinky)
+    > The example hex program was created using  miv-rv32i-systick-blinky in release mode (miv32i-Release). For more information about the project go to bare metal example: [miv-rv32i-systick-blinky](https://github.com/Mi-V-Soft-RISC-V/miv-rv32-bare-metal-examples/tree/main/driver-examples/miv-rv32-hal/miv-rv32i-systick-blinky)
 
 * **miv-rv32-ess-bootloader.elf**: The supplied Bootloader .elf file is used to copy data from the LSRAM (SRC_MEM) @0x8000_0000 to external I2C Flash memory (Dual EE Click board required)
     > The .elf program was compiled using 'miv-rv32-ess-bootloader' in Bootstrap mode. For more information about the project go to bare metal example: [miv-rv32-ess-bootloader](https://github.com/Mi-V-Soft-RISC-V/miv-rv32-bare-metal-examples/tree/main/applications/bootloaders/miv-rv32-bootloader)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To download or clone the repository:
 
 
 # Libero Projects
-The Libero_Projects folder contains [sample Mi-V Libero designs](Libero_Projects) for Libero SoC v2022.1. Libero projects for older Libero releases can be downloaded from their [tags](https://github.com/Mi-V-Soft-RISC-V/Future-Avalanche-Board/releases) in this repository.
+The Libero_Projects folder contains [sample Mi-V Libero designs](Libero_Projects) for Libero SoC v2022.2. Libero projects for older Libero releases can be downloaded from their [tags](https://github.com/Mi-V-Soft-RISC-V/Future-Avalanche-Board/releases) in this repository.
 
 ## Design Features
 The Libero designs include the following features:
@@ -40,7 +40,7 @@ The FlashPro_Express_Projects folder contains the pre-generated programming file
 # Design Tools
 The following design tools are required.
 
-## Libero SoC v2022.1
+## Libero SoC v2022.2
 [Libero SoC](https://www.microsemi.com/products/fpga-soc/design-resources/design-software/libero-soc#downloads) is Microchip's FPGA design software.
 
 ## FlashPro Express

--- a/README.md
+++ b/README.md
@@ -24,11 +24,10 @@ The Libero_Projects folder contains [sample Mi-V Libero designs](Libero_Projects
 
 ## Design Features
 The Libero designs include the following features:
-* A soft RISC-V processor.
+* A soft RISC-V processor operating at 50 MHz
 * A RISC-V debug block allowing on-target debug using SoftConsole
-* An Extended subsystem with peripheral cores
-* The operating frequency of the design is 50MHz
-* Target memory is SRAM/TCM (32kB)
+* An Extended Subsystem with integrated peripherals
+* Target SRAM/TCM memory (32kB)
 * User peripherals: MIV_ESS, 2 Timers, UART, 2 GPIO Inputs and 4 GPIO Outputs (GPIOs use fixed configs for simplicity and better resource utilization)
 
 ## Target Hardware

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The Libero_Projects folder contains [sample Mi-V Libero designs](Libero_Projects
 The Libero designs include the following features:
 * A soft RISC-V processor.
 * A RISC-V debug block allowing on-target debug using SoftConsole
+* An Extended subsystem with peripheral cores
 * The operating frequency of the design is 50MHz
 * Target memory is SRAM/TCM (32kB)
 * User peripherals: MIV_ESS, 2 Timers, UART, 2 GPIO Inputs and 4 GPIO Outputs (GPIOs use fixed configs for simplicity and better resource utilization)


### PR DESCRIPTION
The readmes for this hardware platform have been updated to reflect
features brought in with this update.

Readme for DGC configuration/s has had wording changed for MIV_ESS
memory map. Additionally, the link to baremetal library's
"miv-rv32i-systick-blinky"
software project, has been re-established.

Signed-off: Sebastian Slowikowski <seb.slowikowski@microchip.com>